### PR TITLE
[KLTB002-14239] Add Danger rule for Jira ticket

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+require 'active_support/core_ext/string/output_safety'
+
+def verifyPRTitle()
+    title = github.pr_title
+    if title.size < 17
+        warn("Title too short. It should fit '[KLTB002-JIRA_TICKET_NO] TITLE' template.")
+    else 
+        if title.start_with?("[KLTB002-")
+            jiraTicketNumber = title[9, 5]
+            trailingBracket = title[14, 2]
+            warn "Title trailing bracket or space missing. It should fit '[KLTB002-JIRA_TICKET_NO] TITLE template'" unless trailingBracket == "] "
+            warn "Invalid JIRA ticket number It should fit [KLTB002-JIRA_TICKET_NO] TITLE template'" unless jiraTicketNumber.scan(/\D/).empty?
+            jiraTicketBaseString = "https://kolibree.atlassian.net/browse/KLTB002-#{jiraTicketNumber}"
+            jiraTicket = jiraTicketBaseString.gsub(URI.regexp, '<a href="\0">\0</a>').html_safe
+            message "This PR is related to JIRA " + jiraTicket
+            description = github.pr_body
+            warn "JIRA link in the description does not match pull request title." unless description.include?(jiraTicketBaseString)
+        else
+            warn "Invalid PR title. It should fit [KLTB002-JIRA_TICKET_NO] TITLE template"
+        end
+    end
+end
+
+verifyPRTitle()

--- a/Dangerfile
+++ b/Dangerfile
@@ -2,25 +2,55 @@
 
 require 'active_support/core_ext/string/output_safety'
 
-def verifyPRTitle()
+def verifyPRTitle(jiraDomainUrl, jiraProjectKey)
     title = github.pr_title
-    if title.size < 17
-        warn("Title too short. It should fit '[KLTB002-JIRA_TICKET_NO] TITLE' template.")
-    else 
-        if title.start_with?("[KLTB002-")
-            jiraTicketNumber = title[9, 5]
-            trailingBracket = title[14, 2]
-            warn "Title trailing bracket or space missing. It should fit '[KLTB002-JIRA_TICKET_NO] TITLE template'" unless trailingBracket == "] "
-            warn "Invalid JIRA ticket number It should fit [KLTB002-JIRA_TICKET_NO] TITLE template'" unless jiraTicketNumber.scan(/\D/).empty?
-            jiraTicketBaseString = "https://kolibree.atlassian.net/browse/KLTB002-#{jiraTicketNumber}"
-            jiraTicket = jiraTicketBaseString.gsub(URI.regexp, '<a href="\0">\0</a>').html_safe
-            message "This PR is related to JIRA " + jiraTicket
-            description = github.pr_body
-            warn "JIRA link in the description does not match pull request title." unless description.include?(jiraTicketBaseString)
-        else
-            warn "Invalid PR title. It should fit [KLTB002-JIRA_TICKET_NO] TITLE template"
-        end
+
+    # 
+    # Shortest acceptable title contains Jira key in brackets, 
+    # a space and at least one char. For example:
+    # 
+    # `[jiraProjectKey-1] A`
+    # 
+    minTitleLength = jiraProjectKey.size + 6
+
+    if title.size < minTitleLength
+        warn("Title too short. It should fit '[#{jiraProjectKey}-JIRA_TICKET_NO] TITLE' template.")
+        return
     end
+
+    unless title =~ /\[#{jiraProjectKey}-[0-9]+\]\s\S+/
+        warn "Invalid PR title. It should fit `[#{jiraProjectKey}-JIRA_TICKET_NO] TITLE` template"
+        return
+    end
+
+    sanitizedTitle = title
+    sanitizedTitle.slice! "[#{jiraProjectKey}-"
+    indexOfClosingBracket = sanitizedTitle.index(']')
+
+    if indexOfClosingBracket.nil? || indexOfClosingBracket == 0
+        # As we're testing regexp before, this should not happen, but let's be sure
+        warn "Invalid PR title. It should fit `[#{jiraProjectKey}-JIRA_TICKET_NO] TITLE` template"
+        return
+    end
+
+    jiraTicketNumber = sanitizedTitle[0..indexOfClosingBracket-1]
+    jiraTicketBaseString = "#{jiraDomainUrl}/browse/#{jiraProjectKey}-#{jiraTicketNumber}"
+    jiraTicket = jiraTicketBaseString.gsub(URI.regexp, '<a href="\0">\0</a>').html_safe
+    message "This PR is related to JIRA " + jiraTicket
+
+    description = github.pr_body
+    warn "JIRA link in the description does not match pull request title." unless description.include?(jiraTicketBaseString)
 end
 
-verifyPRTitle()
+ENV_JIRA_DOMAIN_URL = "DANGER_JIRA_DOMAIN_URL"
+ENV_JIRA_PROJECT_KEY = "DANGER_JIRA_PROJECT_KEY"
+
+jiraDomainUrl = ENV[ENV_JIRA_DOMAIN_URL]
+jiraProjectKey = ENV[ENV_JIRA_PROJECT_KEY]
+
+fail "Jira domain URL has to be passed via `#{ENV_JIRA_DOMAIN_URL}` env variable. Check your configuration." if jiraDomainUrl.nil? or jiraDomainUrl.empty?
+fail "Jira project key has to be passed via `#{ENV_JIRA_PROJECT_KEY}` env variable. Check your configuration." if jiraProjectKey.nil? or jiraProjectKey.empty?
+fail "Jira domain URL (#{jiraDomainUrl}) cannot be blank" if jiraDomainUrl.nil?.! and jiraDomainUrl.empty?
+fail "Jira project key (#{jiraProjectKey}) cannot be blank" if jiraProjectKey.nil?.! and jiraProjectKey.empty?
+
+verifyPRTitle(jiraDomainUrl, jiraProjectKey) unless jiraDomainUrl.nil? or jiraProjectKey.nil? or jiraDomainUrl.empty? or jiraProjectKey.empty?


### PR DESCRIPTION
## Description
This PR adds Danger rule for checking Jira ticket names in PR titles. This rule can be later integrated in other repositories (Android integration was done [here](https://github.com/kolibree-git/android-monorepo/pull/1854))

## Preflight Checklist

- [x] No warnings or linting issues have been introduced

##
#### Jira ticket
For more details check the [JIRA ticket](https://kolibree.atlassian.net/browse/KLTB002-14239).

#### How it works
Danger will push a warning message to your PR if it sees an issue or a success message if everything is ok.

Success message:
![image](https://user-images.githubusercontent.com/23481409/104577094-5ef31880-5659-11eb-9eb1-2908ddc489e0.png)

#### Testing
- Install Danger in your CI pipeline if you don't have it yet (check Confluence for more info what's needed)
- Copy the Danger file to your repo
- Execute Danger rule in your CI pipeline (check Confluence how to do that)
- Create test PR without Jira ticket in the title
- Check Danger message - it should show the error message
- Update the PR title & put Jira ticket link in the description
- Restart the build
- Check Danger message - it should show the success message

#### Additional info
Confluence documentation: https://kolibree.atlassian.net/wiki/spaces/SOF/pages/957841473/Workflow#Danger-setup