### PR TITLE
[feature][KLBT002-14242] Kolibree output and GitHub support

### DIFF
--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -295,6 +295,7 @@ include_merge = True
 #]
 revs = []
 
+
 ##
 ## Kolibree Output additions
 ##

--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -137,7 +137,7 @@ section_regexps = [
 ## Additionally, you can `pipe` the provided filters, for instance:
 #body_process = Wrap(regexp=r'\n(?=\w+\s*:)') | Indent(chars="  ")
 #body_process = Wrap(regexp=r'\n(?=\w+\s*:)')
-# body_process = noop
+#body_process = noop
 body_process = ReSub(r'((^|\n)[A-Z]\w+(-\w+)*: .*(\n\s+.*)*)+$', r'') | strip
 
 
@@ -147,9 +147,6 @@ body_process = ReSub(r'((^|\n)[A-Z]\w+(-\w+)*: .*(\n\s+.*)*)+$', r'') | strip
 ## be used in the changelog.
 ##
 ## Available constructs are those listed in ``body_process`` doc.
-# subject_process = (strip |
-#     ReSub(r'^(Fix)', r'R')
-# )
 subject_process = (strip |
     ReSub(r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n@]*)(@[a-z]+\s+)*$', r'\4') |
     SetIfEmpty("No commit message.") | ucfirst | final_dot)

--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -82,16 +82,22 @@ ignore_regexps = [
 ## whenever you are tweaking this variable.
 ##
 section_regexps = [
-    ('New', [
-        r'^[nN]ew\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
-     ]),
-    ('Changes', [
-        r'^[cC]hg\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
-     ]),
     ('Fix', [
-        r'^[fF]ix\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
-     ]),
+        r'''(?ix)
+            (^fix)
+            |
+            (^\[fixt)
+        ''',
+    ]),
+    ('Feature', [
+        r'''(?ix)^
+            (
+                (\[?feature)
+                |
+                (\[?KLTB00)
+            )''',
 
+    ]),
     ('Other', None ## Match all lines
      ),
 
@@ -131,7 +137,7 @@ section_regexps = [
 ## Additionally, you can `pipe` the provided filters, for instance:
 #body_process = Wrap(regexp=r'\n(?=\w+\s*:)') | Indent(chars="  ")
 #body_process = Wrap(regexp=r'\n(?=\w+\s*:)')
-#body_process = noop
+# body_process = noop
 body_process = ReSub(r'((^|\n)[A-Z]\w+(-\w+)*: .*(\n\s+.*)*)+$', r'') | strip
 
 
@@ -141,6 +147,9 @@ body_process = ReSub(r'((^|\n)[A-Z]\w+(-\w+)*: .*(\n\s+.*)*)+$', r'') | strip
 ## be used in the changelog.
 ##
 ## Available constructs are those listed in ``body_process`` doc.
+# subject_process = (strip |
+#     ReSub(r'^(Fix)', r'R')
+# )
 subject_process = (strip |
     ReSub(r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n@]*)(@[a-z]+\s+)*$', r'\4') |
     SetIfEmpty("No commit message.") | ucfirst | final_dot)
@@ -157,12 +166,7 @@ tag_filter_regexp = r'^[0-9]+\.[0-9]+(\.[0-9]+)?$'
 ##
 ## This label will be used as the changelog Title of the last set of changes
 ## between last valid tag and HEAD if any.
-import os.path
-unreleased_version_label = lambda: swrap(
-    (["bash"] if WIN32 else []) +
-    [os.path.join(".", "autogen.sh"), "--get-version"],
-shell=False)
-
+unreleased_version_label = "(unreleased)"
 
 
 ## ``output_engine`` is a callable
@@ -193,10 +197,11 @@ shell=False)
 ##        Examples:
 ##           - makotemplate("restructuredtext")
 ##
-output_engine = rest_py
+#output_engine = rest_py
 #output_engine = mustache("restructuredtext")
 #output_engine = mustache("markdown")
 #output_engine = makotemplate("restructuredtext")
+output_engine = kolibree_output
 
 
 ## ``include_merge`` is a boolean
@@ -230,7 +235,7 @@ include_merge = True
 ##        Outputs directly to standard output
 ##        (This is the default)
 ##
-##   - FileInsertAtFirstRegexMatch(file, pattern, idx=lamda m: m.start(), flags)
+##   - FileInsertAtFirstRegexMatch(file, pattern, idx=lamda m: m.start())
 ##
 ##        Creates a callable that will parse given file for the given
 ##        regex pattern and will insert the output in the file.
@@ -292,3 +297,10 @@ include_merge = True
 #    "HEAD"
 #]
 revs = []
+
+##
+## Kolibree Output additions
+##
+## Github repo
+##
+github_repo = "kolibree-git/gitchangelog"

--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -94,7 +94,7 @@ section_regexps = [
             (
                 (\[?feature)
                 |
-                (\[?KLTB00)
+                (\[?KLTB002)
             )''',
 
     ]),

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1369,6 +1369,7 @@ def kolibree_output(data, opts={}):
 
     # GitHub
     github = None
+    re_pr_num = None
     if Github:
         try:
             github = Github(token)
@@ -1421,16 +1422,17 @@ def kolibree_output(data, opts={}):
         if commit["body"]:
             entry += "\n" + indent(commit["body"]) + "\n"
         else:
-            # Get GitHub PR description/body
-            pr_num = re_pr_num.search(commit["subject"])
-            pr_num = pr_num.groups()[0] if pr_num else None
-            if pr_num:
-                try:
-                    pull = repo.get_pull(int(pr_num))
-                    entry += "\n```\n" + pull.body + "\n```\n"
-                except Exception as e:
-                    err(f"Unable to retrieve PR #{pr_num} from Github.")
-                    err(f"Exception: {e}")
+            if re_pr_num:
+                # Get GitHub PR description/body
+                pr_num = re_pr_num.search(commit["subject"])
+                pr_num = pr_num.groups()[0] if pr_num else None
+                if pr_num:
+                    try:
+                        pull = repo.get_pull(int(pr_num))
+                        entry += "\n```\n" + pull.body + "\n```\n"
+                    except Exception as e:
+                        err(f"Unable to retrieve PR #{pr_num} from Github.")
+                        err(f"Exception: {e}")
 
         return entry
 

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1364,7 +1364,7 @@ def kolibree_output(data, opts={}):
 
     token = opts.get("github_token")
     repo = opts.get("github_repo")
-    if not any([token, repo]):
+    if not all([token, repo]):
         die("Github token, repo and/or PR regexp config is missing.")
 
     # GitHub

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -31,6 +31,12 @@ except ImportError:  ## pragma: no cover
     mako = None
 
 
+try:
+    from github import Github
+except ImportError:
+    Github = None
+
+
 __version__ = "%%version%%"  ## replaced by autogen.sh
 
 DEBUG = None
@@ -1349,6 +1355,93 @@ def rest_py(data, opts={}):
             yield render_version(version) + "\n\n"
 
 
+@available_in_config
+def kolibree_output(data, opts={}):
+    """Returns Markdown Text changelog content from data
+
+    Connect to GitHub if commit is missing a body and retrieve PR description.
+    """
+
+    token = opts.get("github_token")
+    repo = opts.get("github_repo")
+    if not any([token, repo]):
+        die("Github token, repo and/or PR regexp config is missing.")
+
+    # GitHub
+    github = None
+    if Github:
+        try:
+            github = Github(token)
+            repo = github.get_repo(repo)
+        except Exception:
+            die("Unable to connect to Github")
+
+        re_pr_num = re.compile(
+            # Example: "Title of commit (#PR_NUM)"
+            r"""
+                \(
+                \#(\d+)     # wrapped in parentheses for direct number match
+                \)
+                $
+            """,
+            re.X,
+        )
+
+    def rest_title(label, char="="):
+        return (label.strip() + "\n") + (char * len(label) + "\n")
+
+    def render_version(version):
+        title = "%s (%s)" % (version["tag"], version["date"]) \
+                if version["tag"] else \
+                opts["unreleased_version_label"]
+        s = rest_title(title, char="-")
+
+        sections = version["sections"]
+        nb_sections = len(sections)
+        for section in sections:
+
+            section_label = section["label"] if section.get("label", None) \
+                            else "Other"
+
+            if not (section_label == "Other" and nb_sections == 1):
+                s += "\n" + rest_title(section_label, "~")
+
+            for commit in section["commits"]:
+                s += render_commit(commit)
+        return s
+
+    def render_commit(commit, opts=opts):
+        subject = commit["subject"]
+
+        subject += " [%s]" % (", ".join(commit["authors"]), )
+
+        entry = indent('\n'.join(textwrap.wrap(subject)),
+                       first="- ").strip() + "\n"
+
+        if commit["body"]:
+            entry += "\n" + indent(commit["body"]) + "\n"
+        else:
+            # Get GitHub PR description/body
+            pr_num = re_pr_num.search(commit["subject"])
+            pr_num = pr_num.groups()[0] if pr_num else None
+            if pr_num:
+                try:
+                    pull = repo.get_pull(int(pr_num))
+                    entry += "\n```\n" + pull.body + "\n```\n"
+                except Exception as e:
+                    err(f"Unable to retrieve PR #{pr_num} from Github.")
+                    err(f"Exception: {e}")
+
+        return entry
+
+    if data["title"]:
+        yield rest_title(data["title"], char="=") + "\n\n"
+
+    for version in data["versions"]:
+        if len(version["sections"]) > 0:
+            yield render_version(version) + "\n\n"
+
+
 ## formatter engines
 
 if pystache:
@@ -1639,6 +1732,10 @@ def changelog(output_engine=rest_py,
     opts = {
         'unreleased_version_label': unreleased_version_label,
     }
+    github_opts = {
+        'github_token': kwargs.pop('github_token', None),
+        'github_repo': kwargs.pop('github_repo', None),
+    }
 
     ## Setting main container of changelog elements
     title = None if kwargs.get("revlist") else "Changelog"
@@ -1656,6 +1753,7 @@ def changelog(output_engine=rest_py,
     else:
         data["versions"] = itertools.chain([first_version], versions)
 
+    opts.update(**github_opts)
     return output_engine(data=data, opts=opts)
 
 ##
@@ -1964,6 +2062,10 @@ def main():
             body_process=config.get("body_process", noop),
             subject_process=config.get("subject_process", noop),
             log_encoding=log_encoding,
+            # Kolibree output additions
+            # -------------------------
+            github_token=os.environ.get("GITHUB_TOKEN", None),
+            github_repo=config.get("github_repo", None),
         )
 
         if isinstance(content, basestring):

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1438,8 +1438,8 @@ def kolibree_output(data, opts={}):
                         if body:
                             entry += "\n```\n" + body + "\n```\n"
                     except Exception as e:
-                        err(f"Unable to retrieve PR #{pr_num} from Github.")
-                        err(f"Exception: {e}")
+                        err("Unable to retrieve PR #{} from Github.".format(pr_num))
+                        err("Exception: {}".format(e))
 
         return entry
 

--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1414,8 +1414,6 @@ def kolibree_output(data, opts={}):
     def render_commit(commit, opts=opts):
         subject = commit["subject"]
 
-        subject += " [%s]" % (", ".join(commit["authors"]), )
-
         entry = indent('\n'.join(textwrap.wrap(subject)),
                        first="- ").strip() + "\n"
 


### PR DESCRIPTION
## Description
This Pull Request adds `kolibree_output` engine with Github support.

## Preflight Checklist

- [x] No warnings or linting issues have been introduced

##
#### Jira ticket
For more details check the [JIRA ticket](https://kolibree.atlassian.net/browse/KLTB002-14242).

#### How it works
By adding a new output engine `kolibree_output` we can adjust output for Kolibree changelog as we want wo changing any existing functionality. 


#### Additional info
Default `rc` config file has been changed to include/group by `Feature`, `Fix` and `Other` sections.
Github repository should be explicitly added through `rc` file.
Github access token should be available through environment (`os.environ.get`)