### PR TITLE
[fix][no-jira] Add EntryType enum check in jira ticket retrieval setup

### DIFF
--- a/src/gitchangelog/gitchangelog.py
+++ b/src/gitchangelog/gitchangelog.py
@@ -1306,7 +1306,7 @@ def kolibree_output(data: dict, opts: dict = {}) -> Generator[str, None, None]:
         if ticket:
             try:
                 fields = "summary,issuetype"
-                if entry_desc == "jira":
+                if entry_desc == EntryType.jira.value:
                     fields += ",description"
                 issue = jira.issue(ticket, fields=fields)
                 subject = "[{}]({}) {}".format(


### PR DESCRIPTION
## Description
This Pull Request add EntryType enum check in jira ticket retrieval setup.

## Preflight Checklist

- [x] No warnings or linting issues have been introduced

##
#### Jira ticket
--