### PR TITLE
[feature][KLTB002-15633] Add PyGithub and jira libs to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,10 @@ package_dir =
 packages: find:
 include_package_data = True
 python_requires = >= 3.6
-install_requires = setuptools
+install_requires = 
+    setuptools
+    PyGithub>=1.54
+    jira>=2.0.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
## Description
This Pull Request add `PyGithub` and `jira` libs dependencies to `setup.cfg`.

## Preflight Checklist

- [x] No warnings or linting issues have been introduced

##
#### Jira ticket
For more details check the [JIRA ticket](https://kolibree.atlassian.net/browse/KLTB002-15633).

#### Additional info
We are installing gitchangelog package directly from github (`git+https://github.com/kolibree-git/gitchangelog.git@main`) and PyGithub and jira libs are needed for expected changelog generation functioning by using `kolibree_output` generating function.